### PR TITLE
Add a "report" of the coordinates of some of the markers

### DIFF
--- a/css/webclient.less
+++ b/css/webclient.less
@@ -1791,3 +1791,14 @@ body.wwt-webclient-wrapper.mobile{
     margin-top: 4px;
   }
 }
+
+body.wwt-webclient-wrapper div.modal div.starhunt-marker-report {
+  textarea {
+    width: 550px;
+    height: 400px;
+  }
+
+  .copy-btn {
+    margin-top: 8px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -719,7 +719,15 @@
             </div>
 
             <div class="leftpad toppad">
-              <a class="btn" ng-click="on_create_marker_click()">Create Marker Here</a>
+              <a class="btn" ng-click="on_create_marker_click(false)">Create Marker Here</a>
+            </div>
+
+            <div class="leftpad toppad">
+              <a class="btn" ng-click="on_create_marker_click(true)">Create Coordinate Marker</a>
+            </div>
+
+            <div class="leftpad toppad">
+              <a class="btn" ng-click="on_report_coordinates()">Report Coordinates</a>
             </div>
 
             <h4><b>Bullseye</b></h4>

--- a/views/modals/starhunt-marker-report.html
+++ b/views/modals/starhunt-marker-report.html
@@ -1,0 +1,10 @@
+﻿<div class="modal-header" data-movable="1" data-movable-target=".modal-dialog">
+  <i class="fa fa-close pull-right" ng-click="$hide()"></i>
+  <h5 localize="Marker Coordinates"></h5>
+</div>
+
+<div class="modal-body starhunt-marker-report">
+  <textarea class="starhunt-marker-report-text" readonly ng-model="coordinate_text"></textarea>
+
+  <a class="btn copy-btn" ng-click="copy_to_clipboard()">Copy to Clipboard</a>
+</div>


### PR DESCRIPTION
There are now two kinds of markers, "coordinate markers" and regular ones. There is a new button, "Report Coordinates", that will open a modal dialog box that prints out the coordinates of the "coordinate markers" and provides a button to copy them to the clipboard. The coordinates are printed out to second/arcsecond precision.