### PR TITLE
changing from space to tab to separate coordinates

### DIFF
--- a/controllers/StarHuntController.js
+++ b/controllers/StarHuntController.js
@@ -269,7 +269,7 @@
 
             if (m.starhunt_is_coord_marker) {
               text += util.formatHms(m.starhunt_ra_hours, false, false, false);
-              text += " ";
+              text += "\t";
               text += util.formatHms(m.starhunt_dec_deg, false, true, false);
               text += "\n";
             }


### PR DESCRIPTION
I want to copy-paste into a excel table and be able to paste RA and DEC in different columns.
As it is now RA and DEC go to the same column, maybe because the separator is a space