### PR TITLE
Requested UX tweaks

### DIFF
--- a/controllers/StarHuntController.js
+++ b/controllers/StarHuntController.js
@@ -323,6 +323,7 @@
       ];
 
       $scope.starhunt_context_name = 'None';
+      $scope.starhunt_cur_bg_opacity = 100;  // sync with index.html
 
       var active_context_setname = null,
           context_layers = {};
@@ -375,8 +376,23 @@
 
         // Show it.
 
+        $scope.starhunt_cur_bg_opacity = 100;
         layer.set_opacity(1);
       };
+
+      $scope.on_bg_opacity_changed = function() {
+        if (active_context_setname == null) {
+          return;
+        }
+
+        var layer = context_layers[active_context_setname];
+
+        if (!layer) {
+          return;
+        }
+
+        layer.set_opacity(0.01 * $scope.starhunt_cur_bg_opacity);
+      }
 
       // Final initialization
 

--- a/controllers/StarHuntController.js
+++ b/controllers/StarHuntController.js
@@ -230,7 +230,10 @@
 
       // Markers
 
-      var MARKER_SIZE_ARCSEC = 3;
+      var MARKER_SIZES_ARCSEC = {
+        'IRDC': 3,
+        'SOMA': 1,
+      };
 
       $scope.on_create_marker_click = function(is_coord) {
         if (current_item == null) {
@@ -242,7 +245,7 @@
         m.set_skyRelative(true);
         m.set_fill(true);
         //m.set_fillColor('#ffff99');
-        var rad = arcsec_to_circle_radius(MARKER_SIZE_ARCSEC, wwt.viewport.Dec);
+        var rad = arcsec_to_circle_radius(MARKER_SIZES_ARCSEC[current_item._Source_Type], wwt.viewport.Dec);
         m.set_radius(rad);
         m.setCenter(wwt.viewport.RA * 15, wwt.viewport.Dec);
         wwt.wc.addAnnotation(m);

--- a/controllers/StarHuntController.js
+++ b/controllers/StarHuntController.js
@@ -231,6 +231,9 @@
 
       // Markers
 
+      var COORDINATE_MARKER_COLOR = '#ff0000',
+          REGULAR_MARKER_COLOR = '#ffff99';
+
       var MARKER_SIZES_ARCSEC = {
         'IRDC': 3,
         'SOMA': 1,
@@ -252,11 +255,10 @@
         wwt.wc.addAnnotation(m);
 
         m.starhunt_is_coord_marker = is_coord;
-        m.report_marker = is_coord;
-        if (m.starhunt_is_coord_marker) { // adding these 4 line to select the colour of the marker
-          m.set_fillColor('#ff0000'); // if it is a coordinate marker, print it red
-        } else { //
-          m.set_fillColor('#ffff99'); // if it is a non-coordinate marker, print it yellow
+        if (m.starhunt_is_coord_marker) {
+          m.set_fillColor(COORDINATE_MARKER_COLOR);
+        } else {
+          m.set_fillColor(REGULAR_MARKER_COLOR);
         }
         m.starhunt_ra_hours = wwt.viewport.RA; // can't get these back after creation!
         m.starhunt_dec_deg = wwt.viewport.Dec;
@@ -272,7 +274,7 @@
           for (var i = 0; i < current_item._markers.length; i++) {
             var m = current_item._markers[i];
 
-            if (m.starhunt_is_coord_marker && m.report_marker) {
+            if (m.starhunt_is_coord_marker) {
               var pa_rad = sphbear(
                 current_item._source_dec_deg * D2R,
                 current_item._source_ra_deg * D2R,
@@ -309,7 +311,11 @@
         scope.done_with_these = function() {
           for (var i = 0; i < scope.item._markers.length; i++) {
             var m = scope.item._markers[i];
-            m.report_marker = false;
+
+            if (m.starhunt_is_coord_marker) {
+              m.starhunt_is_coord_marker = false;
+              m.set_fillColor(REGULAR_MARKER_COLOR);
+            }
           }
 
           scope.coordinate_text = "(no active coordinate markers)";

--- a/controllers/StarHuntController.js
+++ b/controllers/StarHuntController.js
@@ -248,6 +248,7 @@
         wwt.wc.addAnnotation(m);
 
         m.starhunt_is_coord_marker = is_coord;
+        m.report_marker = is_coord;
         if (m.starhunt_is_coord_marker) { // adding these 4 line to select the colour of the marker
           m.set_fillColor('#ff0000'); // if it is a coordinate marker, print it red
         } else { //
@@ -267,7 +268,7 @@
           for (var i = 0; i < current_item._markers.length; i++) {
             var m = current_item._markers[i];
 
-            if (m.starhunt_is_coord_marker) {
+            if (m.starhunt_is_coord_marker && m.report_marker) {
               text += util.formatHms(m.starhunt_ra_hours, false, false, false);
               text += "\t";
               text += util.formatHms(m.starhunt_dec_deg, false, true, false);
@@ -284,12 +285,22 @@
 
         var scope = $rootScope.$new();
         scope.coordinate_text = text;
+        scope.item = current_item;
 
         scope.copy_to_clipboard = function() {
           var area = $('.starhunt-marker-report-text');
           area.select();
           document.execCommand('copy');
         };
+
+        scope.done_with_these = function() {
+          for (var i = 0; i < scope.item._markers.length; i++) {
+            var m = scope.item._markers[i];
+            m.report_marker = false;
+          }
+
+          scope.coordinate_text = "(no active coordinate markers)";
+        }
 
         $modal({
           scope: scope,

--- a/controllers/StarHuntController.js
+++ b/controllers/StarHuntController.js
@@ -29,7 +29,8 @@
 
       var D2R = Math.PI / 180.,
           R2D = 180. / Math.PI,
-          D2H = 1. / 15;
+          D2H = 1. / 15,
+          H2R = Math.PI / 12;
 
       // Opacity control
 
@@ -272,9 +273,18 @@
             var m = current_item._markers[i];
 
             if (m.starhunt_is_coord_marker && m.report_marker) {
+              var pa_rad = sphbear(
+                current_item._source_dec_deg * D2R,
+                current_item._source_ra_deg * D2R,
+                m.starhunt_dec_deg * D2R,
+                m.starhunt_ra_hours * H2R
+              );
+
               text += util.formatHms(m.starhunt_ra_hours, false, false, false);
               text += "\t";
               text += util.formatHms(m.starhunt_dec_deg, false, true, false);
+              text += "\t";
+              text += float_to_text(pa_rad * R2D);
               text += "\n";
             }
           }

--- a/css/webclient.less
+++ b/css/webclient.less
@@ -1798,7 +1798,7 @@ body.wwt-webclient-wrapper div.modal div.starhunt-marker-report {
     height: 400px;
   }
 
-  .copy-btn {
+  .btn {
     margin-top: 8px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -769,6 +769,17 @@
                       ng-options="n for n in starhunt_context_names"
                       ng-change="on_context_changed()">
               </select>
+
+              <div class="toppad" ng-show="starhunt_context_name != 'None'">
+                <label id="starhunt-bg-opacity-label" for="starhunt-bg-opacity" localize="Opacity: "></label>
+                <span>{{starhunt_cur_bg_opacity}}%</span>
+                <input id="starhunt-bg-opacity"
+                       class="starhunt-slider"
+                       type="range"
+                       min="0" max="100" step="1" value="100"
+                       ng-model="starhunt_cur_bg_opacity"
+                       ng-change="on_bg_opacity_changed()" />
+              </div>
             </div>
           </div> <!-- when starhunt-ui -->
 

--- a/views/modals/starhunt-marker-report.html
+++ b/views/modals/starhunt-marker-report.html
@@ -6,5 +6,6 @@
 <div class="modal-body starhunt-marker-report">
   <textarea class="starhunt-marker-report-text" readonly ng-model="coordinate_text"></textarea>
 
-  <a class="btn copy-btn" ng-click="copy_to_clipboard()">Copy to Clipboard</a>
+  <a class="btn" ng-click="copy_to_clipboard()">Copy to Clipboard</a>
+  <a class="btn" ng-click="done_with_these()">Done with These Markers</a>
 </div>


### PR DESCRIPTION
Some changes as requested:

- Add position angle to the marker report (#34)
- Change the marker size depending on source type (#33). SOMA markers are now 1 arcsec.
- Add opacity control to the high-rez background imagery (2MASS) (#32)
- Allow markers to be cleared from the marker report (#29)

For the last of these, we add a button labeled "Done with These Markers" to the marker coordinate report. It converts the listed markers from coordinate to non-coordinate markers.