### PR TITLE
change coordinates format to degrees

### DIFF
--- a/controllers/StarHuntController.js
+++ b/controllers/StarHuntController.js
@@ -282,9 +282,9 @@
                 m.starhunt_ra_hours * H2R
               );
 
-              text += util.formatHms(m.starhunt_ra_hours, false, false, false);
+              text += Number((m.starhunt_ra_hours*15).toPrecision(10));
               text += "\t";
-              text += util.formatHms(m.starhunt_dec_deg, false, true, false);
+              text += Number((m.starhunt_dec_deg).toPrecision(10));
               //text += "\t";
               //text += float_to_text(pa_rad * R2D);
               text += "\n";


### PR DESCRIPTION
I have changed the format of RA(HH:MM:SS) and DEC(DD:MM:SS) to degrees in the window dialog to copy. I have also added precision of 10 to avoid printing very large numbers and have a consistent number of significant figures throughout the coordinates markers.